### PR TITLE
chore(repo-config): set baseBranches back to default

### DIFF
--- a/repo-config.json
+++ b/repo-config.json
@@ -4,7 +4,6 @@
   "scanSettings": {
     "configMode": "EXTERNAL",
     "configExternalURL": "https://raw.githubusercontent.com/ibm-skills-network/mend-config/main/whitesource.config",
-    "baseBranches": ["master", "main", "6.x.x", "5.x.x"],
     "exploitability": true
   },
   "checkRunSettings": {


### PR DESCRIPTION
Now that we have disabled scanning on the JupyterLab repo which was the only one we wanted multi-branch scanning on, we can remove this property and just scan the default branch of each repo.