### PR TITLE
chore(global-config): remove explicit list of ignored repos

### DIFF
--- a/global-config.json
+++ b/global-config.json
@@ -1,14 +1,5 @@
 {
   "settingsInheritedFrom": "ibm-mend-config/mend-config@main",
   "repoConfigMode": "pushwhitesourceFile",
-  "CVSSv3": true,
-  "ignoredRepos": {
-    "exactNames": [
-      "ibm-skills-network/cube",
-      "ibm-skills-network/cloud-ide",
-      "ibm-skills-network/theia-full",
-      "ibm-skills-network/jupyterlab",
-      "ibm-skills-network/rstudio"
-    ]
-  }
+  "CVSSv3": true
 }


### PR DESCRIPTION
This list isn't actually respected by Mend and the correct way is to just remove the `.whitesource` file in the relevant repos